### PR TITLE
feat: Add mark todo complete toggle

### DIFF
--- a/App/server/models/Todo.js
+++ b/App/server/models/Todo.js
@@ -42,6 +42,12 @@ const todoSchema = new mongoose.Schema({
     trim: true          // Removes leading/trailing whitespace automatically
   },
 
+  // Boolean to mark the todo task as completed
+  completed: {
+    type: Boolean,
+    default: false // New todos are not completed by default
+  },
+
   // Timestamp for when this todo was created
   createdAt: {
     type: Date,          // Stores date and time

--- a/App/src/App.tsx
+++ b/App/src/App.tsx
@@ -30,6 +30,7 @@ import TodoItem from "./components/TodoItem"; // Child component for individual 
 export interface Todo {
   _id: string;
   text: string;
+  completed: boolean;
   createdAt: string;
 }
 
@@ -72,6 +73,15 @@ function App() {
    * Used to disable buttons and show loading states during operations
    */
   const [loading, setLoading] = useState(false);
+
+  /**
+   * isCompleted: Boolean flag to track if a todo is completed
+   * setIsCompleted: Function to update isCompleted state
+   * Initial value: false
+   *
+   * Used to visually indicate completed tasks
+   */
+  const [isCompleted, setIsCompleted] = useState(false);
 
   // ========================================
   // API CONFIGURATION
@@ -223,17 +233,28 @@ function App() {
    *
    * CALLED WHEN: User clicks the edit icon button next to a todo
    */
-  const editTodo = async (id: string, text: string) => {
+  const editTodo = async (id: string, text?: string, completed?: boolean) => {
     try {
-      // Send PATCH request to backend with specific todo ID in URL and updated text
+      // Send PATCH request to backend with specific todo ID in URL and updated text and/or completed status
       // Example URL: http://localhost:5000/api/todos/507f1f77bcf86cd799439011
-      // Example body: { text: "Updated task description" }
-      await axios.patch(`${API_URL}/${id}`, { text });
+      // Example body for text: { text: "Updated task description" }
+      // Example body for completed: { completed: true }
 
-      // Map through todos and update the one that matches the edited id
-      setTodos(
-        todos.map((todo) => (todo._id === id ? { ...todo, text } : todo))
-      );
+      if (text !== undefined && text !== null && text.trim() !== "") {
+        await axios.patch(`${API_URL}/${id}`, { text });
+
+        // Map through todos and update text of the one that matches the edited id
+        setTodos(
+          todos.map((todo) => (todo._id === id ? { ...todo, text } : todo))
+        );
+      } else if (completed !== undefined && completed !== null) {
+        await axios.patch(`${API_URL}/${id}`, { completed });
+
+        // Map through todos and update completed status of the one that matches the edited id
+        setTodos(
+          todos.map((todo) => (todo._id === id ? { ...todo, completed } : todo))
+        );
+      }
 
       // Return null to indicate success (no error)
       return null;

--- a/App/src/components/TodoItem.tsx
+++ b/App/src/components/TodoItem.tsx
@@ -10,7 +10,7 @@
  * - Event Handlers: Functions that handle user interactions (e.g., button clicks)
  */
 
-import { Trash2, Edit, Save, XCircle } from "lucide-react"; // Icon components for UI
+import { Trash2, Edit, Save, XCircle, CheckCircle, Circle } from "lucide-react"; // Icon components for UI
 import React, { useState } from "react"; // React library and useState hook for managing component state
 import { Todo } from "../App"; // Importing the Todo type from App for type safety
 
@@ -31,7 +31,7 @@ import { Todo } from "../App"; // Importing the Todo type from App for type safe
 interface TodoItemProps {
   todo: Todo;
   deleteTodo: (id: string) => void;
-  editTodo: (id: string, text: string) => Promise<string | null>;
+  editTodo: (id: string, text?: string, completed?: boolean) => Promise<string | null>;
 }
 
 /**
@@ -41,7 +41,7 @@ interface TodoItemProps {
  * Manages its own state for editing and displays the todo text.
  */
 const TodoItem: React.FC<TodoItemProps> = ({
-  todo: { _id, text },
+  todo: { _id, text, completed },
   deleteTodo,
   editTodo,
 }) => {
@@ -82,7 +82,7 @@ const TodoItem: React.FC<TodoItemProps> = ({
    */
   const handleSaveClick = async () => {
     // Call editTodo and await potential error message
-    const errorMsg = await editTodo(_id, editText);
+    const errorMsg = await editTodo(_id, editText, completed);
 
     // If there's an error message, display it; otherwise, exit edit mode
     if (errorMsg) {
@@ -155,6 +155,21 @@ const TodoItem: React.FC<TodoItemProps> = ({
     }
   };
 
+  /**
+   * handleToggleComplete - Toggle Completed Status Handler
+   *
+   * PURPOSE: Toggle the completed status of the todo item
+   *
+   * PROCESS:
+   * 1. Call editTodo function with todo ID and toggled completed status
+   *
+   * UX IMPROVEMENT: Users can easily mark tasks as completed or incomplete
+   */
+  const handleToggleComplete = async () => {
+    // Call editTodo to toggle the completed status
+    await editTodo(_id, undefined, !completed);
+  };
+
   // ========================================
   // JSX RENDER - UI STRUCTURE
   // ========================================
@@ -210,7 +225,9 @@ const TodoItem: React.FC<TodoItemProps> = ({
         <>
           {/* ========== VIEW MODE SECTION ========== */}
           {/* Todo text display */}
-          <span className="text-slate-800 text-lg">{text}</span>
+          <span className={`text-lg ${completed ? "line-through text-gray-400" : "text-slate-800"}`}>
+            {text}
+          </span>
 
           {/* Edit and Delete buttons */}
           <div className="flex items-center space-x-1">
@@ -232,6 +249,18 @@ const TodoItem: React.FC<TodoItemProps> = ({
             >
               <Edit size={20} />{" "}
               {/* Edit icon for edit action from lucide-react */}
+            </button>
+
+            {/* Mark as completed toggle button */}
+            <button
+              onClick={handleToggleComplete}
+              className={`p-2 rounded-lg transition-colors ${
+                completed ? "text-green-600 hover:text-green-700 hover:bg-green-50" : "text-gray-600 hover:text-gray-700 hover:bg-gray-50"
+              }`}
+              title={completed ? "Mark as incomplete" : "Mark as completed"}
+            >
+              {/* CheckCircle icon for completed tasks, Circle icon for incomplete tasks */}
+              {completed ? <CheckCircle size={20} /> : <Circle size={20} />}
             </button>
           </div>
         </>


### PR DESCRIPTION
**Description**

Mark as complete toggle for todo items.

**What’s new:**

* Added mark as complete toggle;
* Updated Todo model; 
* Updated edit patch to handle text and completed fields;
* Added completed todo style.

**Reference**

See: #4 

**Screenshots**

![complete_todo](https://github.com/user-attachments/assets/b01f8b05-0506-45bc-ade4-a056eca7aeb0)

